### PR TITLE
Import module after install

### DIFF
--- a/Dell/Dell_BIOS_Settings_Detection.ps1
+++ b/Dell/Dell_BIOS_Settings_Detection.ps1
@@ -23,11 +23,8 @@ Function Get-DellBIOSProvider
 			Install-Module DellBIOSProvider -ErrorAction SilentlyContinue
 			Write_Log -Message_Type "INFO" -Message "DellBIOSProvider has been installed"  			
 		}
-	Else
-		{
-			Import-Module DellBIOSProvider -ErrorAction SilentlyContinue
-			Write_Log -Message_Type "INFO" -Message "DellBIOSProvider has been imported"  			
-		}
+		Import-Module DellBIOSProvider -ErrorAction SilentlyContinue
+		Write_Log -Message_Type "INFO" -Message "DellBIOSProvider has been imported"  			
 }
 
   

--- a/Dell/Dell_BIOS_Settings_Remediation.ps1
+++ b/Dell/Dell_BIOS_Settings_Remediation.ps1
@@ -23,11 +23,8 @@ Function Get-DellBIOSProvider
 			Install-Module DellBIOSProvider -ErrorAction SilentlyContinue
 			Write_Log -Message_Type "INFO" -Message "DellBIOSProvider has been installed"  			
 		}
-	Else
-		{
-			Import-Module DellBIOSProvider -ErrorAction SilentlyContinue
-			Write_Log -Message_Type "INFO" -Message "DellBIOSProvider has been imported"  			
-		}
+		Import-Module DellBIOSProvider -ErrorAction SilentlyContinue
+		Write_Log -Message_Type "INFO" -Message "DellBIOSProvider has been imported"  			
 }
 
 Get-DellBIOSProvider 	


### PR DESCRIPTION
If the module is not installed on the system it will install it but will not import it due to the `Import-Module` being in the else block. By removing it from the else block it will install it if not installed then import and if already installed just import.